### PR TITLE
Add messages to players

### DIFF
--- a/pack/data/pack/functions/tpnether.mcfunction
+++ b/pack/data/pack/functions/tpnether.mcfunction
@@ -1,5 +1,5 @@
 execute if entity @s[gamemode=spectator] run execute in minecraft:the_nether run tp @s ~ ~ ~
-execute if entity @s[gamemode=spectator] run title @s actionbar {"text":"You were teleporter to The Nether!","color":"green"}
+execute if entity @s[gamemode=spectator] run title @s actionbar {"text":"You were teleported to The Nether!","color":"green"}
 execute if entity @s[gamemode=!spectator] run title @s actionbar {"text":"You can only do this in Spectator Mode!","bold":"true","color":"red"}
 scoreboard players reset @a[scores={tpnether=1..}] tpnether
 scoreboard players enable @a tpnether

--- a/pack/data/pack/functions/tpnether.mcfunction
+++ b/pack/data/pack/functions/tpnether.mcfunction
@@ -1,4 +1,5 @@
 execute if entity @s[gamemode=spectator] run execute in minecraft:the_nether run tp @s ~ ~ ~
+execute if entity @s[gamemode=spectator] run title @s actionbar {"text":"You were teleporter to The Nether!","color":"green"}
 execute if entity @s[gamemode=!spectator] run title @s actionbar {"text":"You can only do this in Spectator Mode!","bold":"true","color":"red"}
 scoreboard players reset @a[scores={tpnether=1..}] tpnether
 scoreboard players enable @a tpnether

--- a/pack/data/pack/functions/tpoverworld.mcfunction
+++ b/pack/data/pack/functions/tpoverworld.mcfunction
@@ -1,5 +1,5 @@
 execute if entity @s[gamemode=spectator] run execute in minecraft:overworld run tp @s ~ ~ ~
-execute if entity @s[gamemode=spectator] run title @s actionbar {"text":"You were teleporter to The Overworld!","color":"green"}
+execute if entity @s[gamemode=spectator] run title @s actionbar {"text":"You were teleported to The Overworld!","color":"green"}
 execute if entity @s[gamemode=!spectator] run title @s actionbar {"text":"You can only do this in Spectator Mode!","bold":"true","color":"red"}
 scoreboard players reset @a[scores={tpoverworld=1..}] tpoverworld
 scoreboard players enable @a tpoverworld

--- a/pack/data/pack/functions/tpoverworld.mcfunction
+++ b/pack/data/pack/functions/tpoverworld.mcfunction
@@ -1,4 +1,5 @@
 execute if entity @s[gamemode=spectator] run execute in minecraft:overworld run tp @s ~ ~ ~
+execute if entity @s[gamemode=spectator] run title @s actionbar {"text":"You were teleporter to The Overworld!","color":"green"}
 execute if entity @s[gamemode=!spectator] run title @s actionbar {"text":"You can only do this in Spectator Mode!","bold":"true","color":"red"}
 scoreboard players reset @a[scores={tpoverworld=1..}] tpoverworld
 scoreboard players enable @a tpoverworld


### PR DESCRIPTION
# Description

Added a couple of messages:
1. Error for non-spectators
2. Confirmation for spectators

Fixes #4 and #2 

## Type of change

{Please delete options that are not relevant.}

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested in singleplayer Minecraft, but I won't see any reason why it shouldn't work on servers.

**Test Configuration**:
* Minecraft version: 1.16.4
* Mods loader: n/a
* Mods: n/a
